### PR TITLE
Fix hook.cpp for insider builds

### DIFF
--- a/clink/process/src/hook.cpp
+++ b/clink/process/src/hook.cpp
@@ -152,30 +152,47 @@ static char* write_trampoline_out(void* const dest, void* const to_hook, funcptr
         patch--;
         offset++;
 
-        if (offset > 125)
-        {
-            LOG("No nop slide or int3 block detected nearby prior to hook target, checked %d prior bytes", offset-1);
-            return nullptr;
-        }
-
         unsigned char c = *patch;
-        if (c == 0xc3){
-            // We've just hit a RET, which likely means that we're in another function.
-            // Good chance the proceeding bytes are garbage, so lets just patch before this.
-            if (offset > rel_jmp_size){
-                LOG("Hit RET, not enough contiguous 0xcc or 0x90 bytes before target, but patching anyway...");
-                offset--;
-                patch++;
-                break;
-            } else {
-                // No room!
-                LOG("No room to patch prior to hook target!");
-                return NULL;
-            }
+        if (offset > 125 || c == 0xc3){
+            // if c is '0xc33, we've hit a RET, which likely means that we're in another function.
+            // Skip the rest.
+            if (c == 0xc3)
+                LOG("Hit RET");
+            LOG("No nop slide or int3 block detected nearby prior to hook target, checked %d prior bytes", offset-1);
+            LOG("Now checking bytes after hook target");
+            // reset for checking forwards
+            viable_bytes = 0;
+            offset = 0;
+            patch = (char*)to_hook;
+            break;
         } else if (c != 0x90 && c != 0xcc)
             viable_bytes = 0;
         else
             viable_bytes++;
+    }
+
+    while (viable_bytes < rel_jmp_size)
+    {
+        patch++;
+        offset--;
+
+        if (offset < -125)
+        {
+            LOG("No nop slide or int3 block detected nearby after hook target, checked %d later bytes", (-1 * (offset+1)));
+            return nullptr;
+        }
+        unsigned char c = *patch;
+        if (c != 0x90 && c != 0xcc)
+            viable_bytes = 0;
+        else
+            viable_bytes++;
+    }
+
+    // If we are patching after rather than before
+    if (offset < 0){
+        // Offset is currently on the fifth byte of our patch area, so back up
+        offset += 4;
+        patch -= 4;
     }
 
     // Patch the API.


### PR DESCRIPTION
Hi,

I had attempted to use your current build for windows insider with your new hook fixes, and it didn't work.

Unfortunately, in the original issue https://github.com/mridgers/clink/issues/543#issuecomment-703037833, I had uploaded the wrong screenshot, and it looks like you were working from that. Unfortunately, ReadConsoleW does not have enough `cc` bytes preceeding it before hitting the end of another function. However, according to Ghidra, this block does not actually get referenced at all, it appears to just be garbage lines:

![image](https://user-images.githubusercontent.com/69168929/94999972-f2ed1880-0571-11eb-9ac1-61959db36d7e.png)

You can see another piece of code jumps into the label, and then makes a RET without calling any of the following lines, and none of those following lines get referenced at all. So, these should be safe to patch.

I've updated hook.cpp to make it so that, if we hit a RET and we have enough room to patch, we just do it anyway.