### PR TITLE
Add VS2019 build using GitHub workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,6 +3,9 @@ on: [push]
 jobs:
   build:
     runs-on: windows-latest
+    strategy:
+      matrix:
+        platform: ["Win32", "x64"]
     steps:
       - name: Set up Git repository
         uses: actions/checkout@v2
@@ -10,15 +13,16 @@ jobs:
         with:
           sdk: "8.1"
           toolset: "14.16"
-      - run: |
+      - name: premake
+        run: |
           $env:Path = "C:\msys64\usr\bin;$env:Path"
           wget https://github.com/premake/premake-core/releases/download/v5.0.0-alpha15/premake-5.0.0-alpha15-windows.zip
           unzip premake-5.0.0-alpha15-windows.zip
           ./premake5.exe vs2019
+      - name: Execute MSBuild
+        run: |
           cd .build/vs2019
-          MSBuild /nologo /property:Configuration=release clink.sln
-          dir bin
-          dir bin\release
+          MSBuild /nologo /property:Configuration=release /p:Platform=${{ matrix.platform }} clink.sln
       - uses: actions/upload-artifact@v2
         with:
           name: release

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,25 @@
+name: Build
+on: [push]
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - name: Set up Git repository
+        uses: actions/checkout@v2
+      - uses: ilammy/msvc-dev-cmd@v1
+        with:
+          sdk: "8.1"
+          toolset: "14.16"
+      - run: |
+          $env:Path = "C:\msys64\usr\bin;$env:Path"
+          wget https://github.com/premake/premake-core/releases/download/v5.0.0-alpha15/premake-5.0.0-alpha15-windows.zip
+          unzip premake-5.0.0-alpha15-windows.zip
+          ./premake5.exe vs2019
+          cd .build/vs2019
+          MSBuild /nologo /property:Configuration=release clink.sln
+          dir bin
+          dir bin\release
+      - uses: actions/upload-artifact@v2
+        with:
+          name: release
+          path: .build/vs2019/bin/release


### PR DESCRIPTION
(Thank you for continuing working on this project. I am eager to test https://github.com/chrisant996/clink/pull/2)

I like the capability of GitHub to build binaries of OSS projects for free. This PR enables that for that projects. After building, the binaries are avilable at the "Actions" page at "Artifacts"

![grafik](https://user-images.githubusercontent.com/1366654/95026217-1dcd8e80-0690-11eb-96f3-a9a949cfb99d.png)
