### PR TITLE
Fix buffer overread caused by usage of strcmp on non null-terminated char arrays

### DIFF
--- a/clink/lib/src/word_classifications.cpp
+++ b/clink/lib/src/word_classifications.cpp
@@ -141,7 +141,7 @@ bool word_classifications::equals(const word_classifications& other) const
 
     if (m_face_definitions.size() != other.m_face_definitions.size())
         return false;
-    if (strcmp(m_faces, other.m_faces) != 0)
+    if (strncmp(m_faces, other.m_faces, m_length) != 0)
         return false;
 
     for (size_t ii = m_face_definitions.size(); ii--;)


### PR DESCRIPTION
Detected by enabling page heap verification on `cmd.exe` as described here: https://learn.microsoft.com/en-us/windows-hardware/drivers/debugger/example-12---using-page-heap-verification-to-find-a-bug