### PR TITLE
Fix crash caused by destruction of non detached threads

### DIFF
--- a/clink/lua/src/async_lua_task.cpp
+++ b/clink/lua/src/async_lua_task.cpp
@@ -101,13 +101,10 @@ void task_manager::on_idle(lua_state& lua)
         }
         else
         {
-            auto next(iter);
-            ++next;
             iter->second->run_callback(lua);
             iter->second->detach();
             m_unref_callbacks.push_back(iter->second->take_callback());
-            m_map.erase(iter);
-            iter = next;
+            iter = m_map.erase(iter);
         }
     }
 
@@ -131,13 +128,10 @@ void task_manager::end_line()
         }
         else
         {
-            auto next(iter);
-            ++next;
             iter->second->detach();
             m_unref_callbacks.push_back(iter->second->take_callback());
             unref = true;
-            m_map.erase(iter);
-            iter = next;
+            iter = m_map.erase(iter);
         }
     }
 

--- a/clink/lua/src/async_lua_task.cpp
+++ b/clink/lua/src/async_lua_task.cpp
@@ -104,6 +104,7 @@ void task_manager::on_idle(lua_state& lua)
             auto next(iter);
             ++next;
             iter->second->run_callback(lua);
+            iter->second->detach();
             m_unref_callbacks.push_back(iter->second->take_callback());
             m_map.erase(iter);
             iter = next;


### PR DESCRIPTION
When an `async_lua_task` is `erase()`'d from the `task_manager`'s `m_map`, the accompanying `std::thread` is destroyed.
In the event that the `task_manager::on_idle` is called before `async_lua_task::proc` has finished it's `do_work()` in order to `detach()` the task thread, a crash is caused in the `async_lua_task`'s destructor by the `m_thread`'s destructor as that sees that the thread is not marked as joined or detached.

The behavior has been noticed on machines with weak compute cores (virtual machines specifically) and on heavily overloaded hosts, such as development machines during heavy compilation duty.

Problem has been traced with debug builds and WinDbg and fixes are tested and work on the affected machines above.