### PR TITLE
Use 3-part version for Nullsoft

### DIFF
--- a/installer/clink.nsi
+++ b/installer/clink.nsi
@@ -29,7 +29,7 @@
 
 ;-------------------------------------------------------------------------------
 Unicode                 true
-Name                    "clink v${CLINK_VERSION}"
+Name                    "clink v${CLINK_VERSION_TAG}"
 ; InstallDir and InstallDirRegKey are omitted so that /D= usage can be detected.
 ; The .onInit function handles providing a default value when /D= is omitted,
 ; reading the InstallDir regkey when appropriate.  The "-" section handles
@@ -99,8 +99,9 @@ Function cleanPreviousInstalls
         StrCmp $2 "" EnumUninstallKeysEnd
 
         ; Skip installs of ourself over an existing installation.
+        ; Starting with v1.4.21 clink will always install overtop itself, so this will only run when upgrading from an older version
         ;
-        StrCmp $2 "clink_${CLINK_VERSION}" EndIfClinkUninstallEntry 0
+        StrCmp $2 "clink" EndIfClinkUninstallEntry 0
             ; Check for uninstaller entries that start "clink_"
             ;
             StrCpy $3 $2 6
@@ -144,20 +145,20 @@ Section "!Application files" app_files_id
 
     ; Create an uninstaller.
     ;
-    StrCpy $uninstallerExe "clink_uninstall_${CLINK_VERSION}.exe"
+    StrCpy $uninstallerExe "clink_uninstall.exe"
     WriteUninstaller "$INSTDIR\$uninstallerExe"
 
     ; Add to "add/remove programs" or "programs and features"
     ;
-    StrCpy $0 "Software\Microsoft\Windows\CurrentVersion\Uninstall\clink_${CLINK_VERSION}"
-    WriteRegStr HKLM $0 "DisplayName"       "Clink v${CLINK_VERSION}"
+    StrCpy $0 "Software\Microsoft\Windows\CurrentVersion\Uninstall\clink"
+    WriteRegStr HKLM $0 "DisplayName"       "Clink v${CLINK_VERSION_TAG}"
     WriteRegStr HKLM $0 "UninstallString"   "$INSTDIR\$uninstallerExe"
     WriteRegStr HKLM $0 "Publisher"         "Christopher Antos"
     WriteRegStr HKLM $0 "DisplayIcon"       "$SYSDIR\cmd.exe,0"
     WriteRegStr HKLM $0 "URLInfoAbout"      "http://chrisant996.github.io/clink"
     WriteRegStr HKLM $0 "HelpLink"          "http://chrisant996.github.io/clink"
     WriteRegStr HKLM $0 "InstallLocation"   "$INSTDIR"
-    WriteRegStr HKLM $0 "DisplayVersion"    "${CLINK_VERSION}"
+    WriteRegStr HKLM $0 "DisplayVersion"    "${CLINK_VERSION_TAG}"
 
     SectionGetSize ${app_files_id} $1
     WriteRegDWORD HKLM $0 "EstimatedSize"   $1
@@ -183,17 +184,17 @@ Section "Add shortcuts to Start menu" section_add_shortcuts
 
     ; Create start menu folder.
     ;
-    StrCpy $0 "$SMPROGRAMS\clink\${CLINK_VERSION}"
+    StrCpy $0 "$SMPROGRAMS\clink"
     CreateDirectory $0
 
     ; Add shortcuts to the program and documentation.
     ;
-    CreateShortcut "$0\Clink v${CLINK_VERSION}.lnk" "$INSTDIR\clink.bat" 'startmenu --profile ~\clink' "$INSTDIR\clink.ico" 0 SW_SHOWMINIMIZED
-    CreateShortcut "$0\Clink v${CLINK_VERSION} Documentation.lnk" "$INSTDIR\clink.html"
+    CreateShortcut "$0\Clink.lnk" "$INSTDIR\clink.bat" 'startmenu --profile ~\clink' "$INSTDIR\clink.ico" 0 SW_SHOWMINIMIZED
+    CreateShortcut "$0\Clink Documentation.lnk" "$INSTDIR\clink.html"
 
     ; Add a shortcut to the uninstaller.
     ;
-    CreateShortcut "$0\Uninstall Clink v${CLINK_VERSION}.lnk" "$INSTDIR\$uninstallerExe"
+    CreateShortcut "$0\Uninstall Clink.lnk" "$INSTDIR\$uninstallerExe"
 SectionEnd
 
 ;-------------------------------------------------------------------------------
@@ -337,10 +338,10 @@ Section "!un.Application files" section_un_app_files
     RMDir /REBOOTOK $INSTDIR\..
 
     ; Remove start menu items and uninstall registry entries.
-    RMDir /r $SMPROGRAMS\clink\${CLINK_VERSION}
+    RMDir /r $SMPROGRAMS\clink
     RMDir $SMPROGRAMS\clink
     DeleteRegKey HKLM Software\Clink
-    DeleteRegKey HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\clink_${CLINK_VERSION}"
+    DeleteRegKey HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\clink"
     DeleteRegValue HKLM "System\CurrentControlSet\Control\Session Manager\Environment" "CLINK_DIR"
 
     SendMessage ${HWND_BROADCAST} ${WM_WININICHANGE} 0 "STR:Environment" /TIMEOUT=1000

--- a/installer/premake5.lua
+++ b/installer/premake5.lua
@@ -209,6 +209,9 @@ newaction {
         local ver_cmd = src:gsub("/", "\\")..clink_exe.." --version"
         for line in io.popen(ver_cmd):lines() do
             version = line
+            -- gsub will match everything until a period is seen and discards the rest of the string
+            -- Since it is greedy, it has the effect of finding only the last period
+            version_tag = version:gsub("(.*)%..*$","%1")
         end
         if not version then
             error("Failed to extract version from build executables")
@@ -245,7 +248,7 @@ newaction {
         if have_nsis then
             local nsis_cmd = have_nsis
             nsis_cmd = nsis_cmd .. " /DCLINK_BUILD=" .. dest
-            nsis_cmd = nsis_cmd .. " /DCLINK_VERSION=" .. version
+            nsis_cmd = nsis_cmd .. " /DCLINK_VERSION_TAG=" .. version_tag
             nsis_cmd = nsis_cmd .. " /DCLINK_SOURCE=" .. code_dir
             nsis_cmd = nsis_cmd .. " " .. code_dir .. "/installer/clink.nsi"
             nsis_ok = exec(nsis_cmd)
@@ -395,7 +398,7 @@ newaction {
         if have_nsis then
             local nsis_cmd = have_nsis
             nsis_cmd = nsis_cmd .. " /DCLINK_BUILD=" .. path.getabsolute(dest)
-            nsis_cmd = nsis_cmd .. " /DCLINK_VERSION=" .. version
+            nsis_cmd = nsis_cmd .. " /DCLINK_VERSION_TAG=" .. version_tag
             nsis_cmd = nsis_cmd .. " /DCLINK_SOURCE=" .. code_dir
             nsis_cmd = nsis_cmd .. " " .. code_dir .. "/installer/clink.nsi"
             nsis_ok = exec(nsis_cmd)


### PR DESCRIPTION
This incorporates my recommended changes from https://github.com/chrisant996/clink/issues/306#issuecomment-1448668498.

* Adds a new parameter call `CLINK_VERSION_TAG` which is calculated in the LUA file. This is done to ensure that the existing implementations of `version` in the LUA file are not disturbed
* Changes Clink to always install over top of the last version. 
  *  Product code has been made to be constant - this means the location of the Uninstall registry entries will always be the same. Running a new installation will update the registry keys that are already existing. This fixes a bug where using `clink upgrade` wouldn't update the product code
  * Start menu no longer has folders for individual versions. Since installing a new version overwrites the existing version, no need to have the version included in the start menu entry. This fixes a bug where using `clink upgrade` wouldn't correct the start menu entry
  * Removes the version tag from the uninstaller. Since all versions will have the same uninstall steps effecting the same registry keys, the version tag is not necessary. This fixes a bug where using `clink upgrade` wouldn't correct the name of the uninstaller (but the uninstaller still performed the correct steps)

I have no way to truly test this on my system, and am relying on my experience with NSIS installers. I encourage testing of this fork by building 2 installers and ensuring updating from a released version like 1.4.18 to Build_1 works and runs properly, and then upgrade from Build_1 to Build_2 works and runs properly, as well as that an uninstall can be performed.