### PR TITLE
Add "Ansi" theme

### DIFF
--- a/clink/app/themes/Ansi.clinktheme
+++ b/clink/app/themes/Ansi.clinktheme
@@ -1,0 +1,37 @@
+# Name: ANSI
+
+[set]
+color.arg                       = bold
+color.arginfo                   = yellow
+color.argmatcher                = bold green
+color.cmd                       = bold
+color.cmdredir                  = yellow
+color.cmdsep                    = magenta
+color.comment_row               = bright cyan on black
+color.common_match_prefix       =
+color.description               = blue
+color.doskey                    = bold cyan
+color.executable                = bold blue
+color.filtered                  = bold
+color.flag                      = cyan
+color.hidden                    = red
+color.histexpand                = bold default on magenta
+color.horizscroll               = default on green
+color.input                     = bright yellow
+color.interact                  = bold
+color.message                   = default
+color.modmark                   =
+color.popup                     =
+color.popup_border              =
+color.popup_desc                =
+color.popup_footer              =
+color.popup_header              =
+color.popup_select              =
+color.popup_selectdesc          =
+color.prompt                    =
+color.readonly                  = green
+color.selected_completion       = sgr 7
+color.selection                 = black on bright yellow
+color.suggestion                = bright black
+color.unexpected                = default
+color.unrecognized              = bright red

--- a/clink/app/themes/Enhanced Defaults 4-bit.clinktheme
+++ b/clink/app/themes/Enhanced Defaults 4-bit.clinktheme
@@ -1,4 +1,4 @@
-# Name: ANSI
+# Name: Enhanced Defaults 4-bit
 
 [set]
 color.arg                       = bold


### PR DESCRIPTION
This "Ansi" theme uses ANSI 4-bit color. So it follows terminal color config.

I wrote it to resemble the "Enhanced Defaults" theme.

![clink_ansi_dimidium](https://github.com/user-attachments/assets/851344dc-5051-4eab-9d4f-3e7517f84a95)

![clink_ansi_sollight](https://github.com/user-attachments/assets/743847ae-501f-46a9-bf47-4bc599f5f2b6)
