### PR TITLE
Optional wide horz scroll markers.

### DIFF
--- a/clink/core/include/core/bldopts.h
+++ b/clink/core/include/core/bldopts.h
@@ -34,6 +34,12 @@
 #define INCLUDE_MATCH_COLORING_RULES
 
 //------------------------------------------------------------------------------
+// Define to make the horizontal scroll markers be 2 characters wide, instead
+// of 1 character wide.  These are the "<" and ">" markers displayed when the
+// input line exceeds the allotted screen area for the input line.
+//#define WIDE_HORZ_SCROLL_MARKERS
+
+//------------------------------------------------------------------------------
 // Debugging options.
 #ifdef DEBUG
 //#define TRACE_ASSERT_STACK

--- a/clink/lib/src/display_readline.cpp
+++ b/clink/lib/src/display_readline.cpp
@@ -84,7 +84,11 @@ int32 rl_visible_rprompt_length = 0;
 #error HANDLE_MULTIBYTE is required.
 #endif
 
+#ifdef WIDE_HORZ_SCROLL_MARKERS
 const uint32 c_horz_scroll_indicator_chars = 2;
+#else
+const uint32 c_horz_scroll_indicator_chars = 1;
+#endif
 
 //------------------------------------------------------------------------------
 extern "C" int32 is_CJK_codepage(UINT cp);


### PR DESCRIPTION
Wide horz scroll markers may be selected at build time in the bldopts.h file.