### PR TITLE
Subset nerd font for embedding prompts in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,10 +76,13 @@ Clink uses [Premake](http://premake.github.io) to generate Visual Studio solutio
 ### Building Documentation
 
 1. Run `npm install -g marked@2.0.1` to install the [marked](https://marked.js.org) markdown library (version 2.0.1).
+2. Run `pip install fonttools brotli lxml` to install the [pyftsubset](https://fonttools.readthedocs.io/en/latest/subset/index.html) font optimizer tool and the [lxml](https://lxml.de/) parser.
 2. Run `premake5.exe docs`.
 
 > [!IMPORTANT]
 > Clink documentation uses marked@2.0.1.  Newer versions of marked have introduced breaking changes, and I haven't yet rewritten how Clink builds the documentation to accommodate the breaking changes.  The security fixes in newer versions aren't relevant since marked is only used at build time with known inputs (the marked library is no longer embedded in the documentation as of commit [d5b39ca](https://github.com/chrisant996/clink/commit/d5b39caf7a1a4353ab8e474e0a26c4f7981e9c3c) in Oct 2020).
+> 
+> The python dependencies are needed in order to make a subset of the Cascadia Code nerd font to display the prompts. This optimization reduces the size (in `woff2`) from ~1220 kB to ~12 kB allowing it to be bundled with the `clink.html` file.
 
 ### Debugging Clink
 

--- a/docs/premake5.lua
+++ b/docs/premake5.lua
@@ -482,10 +482,10 @@ local function do_docs()
     -- Copy font for prompt previews.
     print("")
     print(">> " .. promptFont)
-    local copy_cmd = string.format('copy /y "%s" "%s"', path.join('docs/prompts', promptFont):gsub('/', '\\'), path.join(path.getdirectory(out_path), promptFont):gsub('/', '\\'))
-    local ok, op, exit = os.execute('2>nul 1>nul ' .. copy_cmd)
+    local susbet_cmd = string.format("python docs\\subset.py")
+    local ok, op, exit = os.execute(susbet_cmd)
     if not ok then
-        error(string.format("Error %d copying prompt font file.\n%s", exit, copy_cmd))
+        error(string.format("Error %d making subset of font for prompts.\n%s", exit, susbet_cmd))
     end
 
     print("")

--- a/docs/subset.py
+++ b/docs/subset.py
@@ -1,0 +1,54 @@
+"""Script to extract all glyphs from prompt html and subset the promptFont
+
+This script expects to be adjacent to the 'prompts' directory
+
+Requires: fonttools brotli lxml
+
+Current result (25/09.2025) - 100x decrease:
+Subset CaskaydiaCoveNerdFontMono-Regular.woff2 from 1219.43 kB to 12.47 kB
+"""
+
+from lxml import etree
+from glob import glob
+import os
+import subprocess
+
+TMP_GLYPHS_PATH = ".build/docs/clink_tmp_glyphs.txt"
+prompt_font = "CaskaydiaCoveNerdFontMono-Regular.woff2"
+
+
+def main():
+    docs_path = os.path.dirname(__file__)
+
+    parser = etree.HTMLParser(encoding="utf-8")
+    all_text = ""
+    for file in glob(os.path.join(docs_path, "prompts", "*.html")):
+        filetree = etree.parse(file, parser)
+        all_text += "".join(filetree.getroot().itertext())
+
+    uniqs = set(all_text)
+    unicode_points = []
+    for char in uniqs:
+        unicode_points.append(f"U+{ord(char):04X}")
+
+    with open(TMP_GLYPHS_PATH, "w") as f:
+        f.write(",".join(unicode_points))
+
+    prompt_path = os.path.join(docs_path, "prompts", prompt_font)
+    assert os.path.exists(prompt_path)
+    new_prompt_path = os.path.join(os.path.dirname(TMP_GLYPHS_PATH), prompt_font)
+
+    try:
+        subprocess.run(
+            f"pyftsubset.exe {prompt_path} --unicodes-file={TMP_GLYPHS_PATH} "
+            + f"--flavor=woff2 --output-file={new_prompt_path}",
+            check=True,
+        )
+    except subprocess.CalledProcessError as e:
+        print(f"Error {e.returncode} making a subset of the font file.\n {e.stderr}")
+
+    print(f"Subset {prompt_font} from {os.path.getsize(prompt_path)/1000 :.2f} kB to {os.path.getsize(new_prompt_path)/1000 :.2f} kB")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This reduces the font file's size from 1219.43 kB to 12.47 kB.

The only requirements are `pip install fonttools brotli lxml`.

Using python seemed like the solution as [`fonttools`](https://fonttools.readthedocs.io/en/latest/subset/index.html) is one of the only user friendly tools that allowed us to do this. I was previously using [`glyphhanger`](https://github.com/t18d/glyphhanger) which is js based, but used python `fonttools` to do the actual subsetting (and it's mechanism removed ligatures from the font for some reason, leading to underscores not connecting). So effectively it was just scanning the files to extract unicode points, which is easy to implement, and remove (~200 node) dependencies.

I also found something interesting:
When using the official Cascadia Code Nerd Font, there are visible dots under the headline:
<img width="719" height="74" alt="image" src="https://github.com/user-attachments/assets/dfc025a5-3932-46bb-aa1b-8fb3d3279b48" />

Whereas when using the CaskaydiaCove Nerd Font, the imperfections are not present:
<img width="716" height="72" alt="image" src="https://github.com/user-attachments/assets/e3dc87d3-4840-469c-8aa7-02a052606ccb" />
