### PR TITLE
Use the package id for the winget install command

### DIFF
--- a/clink.html
+++ b/clink.html
@@ -1129,7 +1129,7 @@ Press <kbd>Right</kbd> or <kbd>End</kbd> to insert a suggestion (shown in a mute
 <h1 id="usage"><a class="wlink" href="#usage"><svg width=16 height=16><use href="#wicon"/></svg><span class="wfix">.</span></a>Usage <span class="uplinks"><a href="#toc">top</a></span></h1>
 <h3 id="installation"><a class="wlink" href="#installation"><svg width=16 height=16><use href="#wicon"/></svg><span class="wfix">.</span></a>Installation <span class="uplinks"><a href="#usage">up</a> <a href="#toc">top</a></span></h3>
 <p>You can install Clink by running the setup EXE file from the <a href="https://github.com/chrisant996/clink/releases">releases page</a>.</p>
-<p>Or by using <a href="https://learn.microsoft.com/en-us/windows/package-manager/winget/">winget</a> and running <code>winget install clink</code>.</p>
+<p>Or by using <a href="https://learn.microsoft.com/en-us/windows/package-manager/winget/">winget</a> and running <code>winget install chrisant996.Clink --source winget</code>.</p>
 <p>Or by using <a href="https://scoop.sh/">scoop</a> and running <code>scoop install clink</code>.</p>
 <p>Or by downloading the ZIP file from <a href="https://github.com/chrisant996/clink/releases">releases page</a>, and extracting the files to a directory of your choosing.</p>
 <h3 id="using-clink"><a class="wlink" href="#using-clink"><svg width=16 height=16><use href="#wicon"/></svg><span class="wfix">.</span></a>Using Clink <span class="uplinks"><a href="#usage">up</a> <a href="#toc">top</a></span></h3>


### PR DESCRIPTION
This way it's future-proofed in case anyone publishes another package named clink