### PR TITLE
Prune virtualenv to basename in pure.clinkprompt

### DIFF
--- a/clink/app/themes/pure.clinkprompt
+++ b/clink/app/themes/pure.clinkprompt
@@ -298,7 +298,7 @@ local function virtualenv_func()
         text = venvp
     end
     if text then
-        return text:gsub("\t\r\n", ""):gsub("^%s+", ""):gsub("%s+$", "")
+        return text:gsub("\t\r\n", ""):gsub("^%s+", ""):gsub("%s+$", ""):gsub("\\+$", ""):gsub("^.*\\", "")
     end
 end
 


### PR DESCRIPTION
VIRTUAL_ENV variable contains full path, but in prompt we want less chars with more info.
BTW, original [pure](https://github.com/sindresorhus/pure) prunes venv.